### PR TITLE
Enhancements to diag_revealer.

### DIFF
--- a/diag_revealer/qcom/jni/diag_revealer.c
+++ b/diag_revealer/qcom/jni/diag_revealer.c
@@ -34,18 +34,18 @@
 #include <dlfcn.h>
 
 // #include <linux/diagchar.h>
-#define _GNU_SOURCE 
-#define F_SETPIPE_SZ (F_LINUX_SPECIFIC_BASE + 7) 
+#define _GNU_SOURCE
+#define F_SETPIPE_SZ (F_LINUX_SPECIFIC_BASE + 7)
 #define F_GETPIPE_SZ (F_LINUX_SPECIFIC_BASE + 8)
 #include <fcntl.h>
 
 #include <android/log.h>
 #define  LOG_TAG    "diag_revealer"
 
-#define  LOGE(...)  __android_log_print(ANDROID_LOG_ERROR,LOG_TAG,__VA_ARGS__)
-#define  LOGW(...)  __android_log_print(ANDROID_LOG_WARN,LOG_TAG,__VA_ARGS__)
-#define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)
-#define  LOGI(...)  __android_log_print(ANDROID_LOG_INFO,LOG_TAG,__VA_ARGS__)
+#define  LOGE(...)  __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
+#define  LOGW(...)  __android_log_print(ANDROID_LOG_WARN, LOG_TAG, __VA_ARGS__)
+#define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, __VA_ARGS__)
+#define  LOGI(...)  __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
 
 typedef int (*D_FUNC)(int, int);
 typedef signed int (*I_FUNC)();
@@ -59,12 +59,11 @@ typedef int (*R_FUNC)(const char *);
 // #define BUFFER_SIZE	8192
 // #define BUFFER_SIZE	32768
 #define BUFFER_SIZE	65536
-/* 
+/*
  * size of FIFO pipe between diag_revealer and AndroidDiagMonitor
  */
-// #define DIAG_FIFO_PIPE_SIZE 128*1024*1024 // 128MB
-#define DIAG_FIFO_PIPE_SIZE 10*1024*1024 // 10MB
-
+// #define DIAG_FIFO_PIPE_SIZE (128 * 1024 * 1024) // 128MB
+#define DIAG_FIFO_PIPE_SIZE (10 * 1024 * 1024) // 10MB
 
 #define FIFO_MSG_TYPE_LOG 1
 #define FIFO_MSG_TYPE_START_LOG_FILE 2
@@ -98,7 +97,7 @@ enum remote_procs {
 
 /* IOCTL commands for diagnostic port
  * Reference: https://android.googlesource.com/kernel/msm.git/+/android-6.0.0_r0.9/include/linux/diagchar.h
- */ 
+ */
 #define DIAG_IOCTL_SWITCH_LOGGING	7
 #define DIAG_IOCTL_LSM_DEINIT		9
 #define DIAG_IOCTL_DCI_REG		23
@@ -112,20 +111,18 @@ enum remote_procs {
 #define DIAG_IOCTL_PERIPHERAL_BUF_CONFIG	35
 #define DIAG_IOCTL_PERIPHERAL_BUF_DRAIN		36
 
-
 #define MEMORY_DEVICE_MODE		2
-#define CALLBACK_MODE		6
+#define CALLBACK_MODE			6
 #define TTY_MODE			8
 
-/* 
+/*
  * NEXUS-6-ONLY IOCTL
  * Reference: https://github.com/MotorolaMobilityLLC/kernel-msm/blob/kitkat-4.4.4-release-victara/include/linux/diagchar.h
  */
-#define DIAG_IOCTL_OPTIMIZED_LOGGING	35
+#define DIAG_IOCTL_OPTIMIZED_LOGGING		35
 #define DIAG_IOCTL_OPTIMIZED_LOGGING_FLUSH	36
 
-
-/* 
+/*
  * Buffering mode
  * Reference: https://android.googlesource.com/kernel/msm.git/+/android-6.0.0_r0.9/include/linux/diagchar.h
  */
@@ -134,18 +131,17 @@ enum remote_procs {
 #define DIAG_BUFFERING_MODE_CIRCULAR	2
 #define DEFAULT_LOW_WM_VAL	15
 #define DEFAULT_HIGH_WM_VAL	85
-#define NUM_SMD_DATA_CHANNELS 4
+#define NUM_SMD_DATA_CHANNELS	4
 #define NUM_SMD_CONTROL_CHANNELS NUM_SMD_DATA_CHANNELS
 
 #define MODEM_DATA		0
-#define LAST_PERIPHERAL 3
+#define LAST_PERIPHERAL		3
 
-
-/* 
+/*
  * Structures for DCI client registration
  * Reference: https://android.googlesource.com/kernel/msm.git/+/android-6.0.0_r0.9/drivers/char/diag/diag_dci.h
  */
-#define DCI_LOG_MASK_SIZE		(16*514)
+#define DCI_LOG_MASK_SIZE		(16 * 514)
 #define DCI_EVENT_MASK_SIZE		512
 struct diag_dci_reg_tbl_t {
 	int client_id;
@@ -159,7 +155,7 @@ struct diag_dci_reg_tbl_t {
  * Reference: https://android.googlesource.com/kernel/msm.git/+/android-9.0.0_r0.31/drivers/char/diag/diagchar.h
  */
 struct diag_logging_mode_param_t_pie {
-    uint32_t req_mode;
+	uint32_t req_mode;
 	uint32_t peripheral_mask;
 	uint32_t pd_mask;
 	uint8_t mode_param;
@@ -169,7 +165,7 @@ struct diag_logging_mode_param_t_pie {
 	int peripheral;
 } __packed;
 
-/* 
+/*
  * Android 7.0: switch_logging_mode structure
  * Reference: https://android.googlesource.com/kernel/msm.git/+/android-7.1.0_r0.3/drivers/char/diag/diagchar.h
  */
@@ -188,15 +184,10 @@ struct diag_logging_mode_param_t {
 				| DIAG_CON_LPASS | DIAG_CON_WCNSS \
 				| DIAG_CON_SENSORS)
 
-/* 
+/*
  * Structures for ioctl
  * Reference: https://android.googlesource.com/kernel/msm.git/+/android-6.0.0_r0.9/drivers/char/diag/diagchar_core.c
  */
-
-typedef struct {
-	char *p;
-	size_t len;
-} BinaryBuffer;
 
 struct diag_buffering_mode_t {
 	uint8_t peripheral;
@@ -208,7 +199,6 @@ struct diag_buffering_mode_t {
 #define DIAG_PROC_DCI			1
 #define DIAG_PROC_MEMORY_DEVICE		2
 
-
 struct real_time_vote_t {
 	uint16_t proc;
 	uint8_t real_time_vote;
@@ -218,7 +208,6 @@ struct real_time_query_t {
 	int real_time;
 	int proc;
 } __packed;
-
 
 /*
  * DCI structures
@@ -243,48 +232,51 @@ struct diag_dci_client_tbl {
  * Reference: https://android.googlesource.com/kernel/msm.git/+/android-6.0.0_r0.9/drivers/char/diag/diag_dci.h
  */
 
-char buf_read[BUFFER_SIZE] = {};	// From Haotian: improve reliability
+static char buf_read[BUFFER_SIZE] = {};	// From Haotian: improve reliability
 // int mode = CALLBACK_MODE;	// Logging mode
 static int mode = MEMORY_DEVICE_MODE;	// logging mode
 static uint16_t remote_dev = 0; // MSM (0) or not
-int client_id;	// DCI client ID (allocated by diag driver)
-int fd; //file descriptor to /dev/diag
-
+static int client_id;	// DCI client ID (allocated by diag driver)
+static int fd; // file descriptor to /dev/diag
 
 // Handle SIGPIPE ERROR
-void sigpipe_handler(int signo)
+static void
+sigpipe_handler (int signo)
 {
-  if (signo == SIGPIPE){
-  	  // LOGD("received SIGPIPE. Exit elegantly...\n");
+	if (signo == SIGPIPE) {
+		// LOGD("received SIGPIPE. Exit elegantly...\n");
 
-    /*
-     * Deregister the DCI client
-     */
+		/*
+		 * Deregister the DCI client
+		 */
 
-    /*
-    int ret;
-    ret = ioctl(fd, DIAG_IOCTL_DCI_DEINIT, (char *) &client_id);
-    if (ret < 0) {
-		LOGD("ioctl DIAG_IOCTL_DCI_DEINIT fails, with ret val = %d\n", ret);
-		perror("ioctl DIAG_IOCTL_DCI_DEINIT");
+		/*
+		int ret;
+		ret = ioctl(fd, DIAG_IOCTL_DCI_DEINIT, (char *) &client_id);
+		if (ret < 0) {
+			LOGD("ioctl DIAG_IOCTL_DCI_DEINIT fails, with ret val = %d\n", ret);
+			perror("ioctl DIAG_IOCTL_DCI_DEINIT");
+		} else {
+			printf("ioctl DIAG_IOCTL_DCI_DEINIT: ret=%d\n", ret);
+		}
+		*/
+
+		close(fd);
 	}
-	else
-	{
-		printf("ioctl DIAG_IOCTL_DCI_DEINIT: ret=%d\n", ret);
-	}
-	*/
-
-	close(fd);
-  }
 }
-
 
 static double
-get_posix_timestamp () {
-    struct timeval tv;
-    (void) gettimeofday(&tv, NULL);
-    return (double)(tv.tv_sec) + (double)(tv.tv_usec) / 1.0e6;
+get_posix_timestamp ()
+{
+	struct timeval tv;
+	(void) gettimeofday(&tv, NULL);
+	return (double)(tv.tv_sec) + (double)(tv.tv_usec) / 1.0e6;
 }
+
+typedef struct {
+	char *p;
+	size_t len;
+} BinaryBuffer;
 
 // Read the content of config file.
 // If failed, an empty buffer is returned.
@@ -322,10 +314,10 @@ read_diag_cfg (const char *filename)
 
 	return ret;
 
-	fail:
-		ret.p = NULL;
-		ret.len = 0;
-		return ret;
+fail:
+	ret.p = NULL;
+	ret.len = 0;
+	return ret;
 }
 
 static void
@@ -341,7 +333,6 @@ print_hex (const char *buf, int len)
 		printf("\n");
 }
 
-
 // Write commands to /dev/diag device.
 static int
 write_commands (int fd, BinaryBuffer *pbuf_write)
@@ -349,28 +340,28 @@ write_commands (int fd, BinaryBuffer *pbuf_write)
 	size_t i = 0;
 	char *p = pbuf_write->p;
 
-	//Set fd to non-blocking mode
+	// Set fd to non-blocking mode
 	int flags = fcntl(fd, F_GETFL, 0);
 	fcntl(fd, F_SETFL, flags | O_NONBLOCK);
 
-	//Buffer to mask command
+	// Buffer to mask command
 	char *send_buf = (char *) malloc(pbuf_write->len + 10);
 	if (send_buf == NULL) {
 		perror("Error");
 		return -1;
 	}
 
-    // Metadata for each mask command
-	size_t offset = remote_dev ? 8 : 4; //offset of the metadata (4 bytes for MSM, 8 bytes for MDM)
-	LOGD("write_commands: offset=%d remote_dev=%d\n",offset,remote_dev);
+	// Metadata for each mask command
+	size_t offset = remote_dev ? 8 : 4; // offset of the metadata (4 bytes for MSM, 8 bytes for MDM)
+	LOGD("write_commands: offset=%d remote_dev=%d\n", offset, remote_dev);
 	*((int *)send_buf) = htole32(USER_SPACE_DATA_TYPE);
-	if(remote_dev){
+	if (remote_dev) {
 		/*
-	 	 * MDM device: should let diag driver know it
-	 	 * Reference: diag_get_remote and diagchar_write
-	 	 * in https://android.googlesource.com/kernel/msm.git/+/android-6.0.0_r0.9/drivers/char/diag/diagchar_core.c
-	 	 */
-		*((int *)send_buf+1) =  - MDM;
+		 * MDM device: should let diag driver know it
+		 * Reference: diag_get_remote and diagchar_write
+		 * in https://android.googlesource.com/kernel/msm.git/+/android-6.0.0_r0.9/drivers/char/diag/diagchar_core.c
+		 */
+		*((int *)send_buf+1) =  -MDM;
 	}
 
 	while (i < pbuf_write->len) {
@@ -387,7 +378,7 @@ write_commands (int fd, BinaryBuffer *pbuf_write)
 			fflush(stdout);
 			// int ret = write(fd, (const void *) send_buf, len + 4);
 			int ret = write(fd, (const void *) send_buf, len + offset);
-			// LOGD("write_commands: ret=%d\n",ret);
+			// LOGD("write_commands: ret=%d\n", ret);
 			if (ret < 0) {
 				LOGE("write_commands error (len=%d, offset=%d): %s\n", len, offset, strerror(errno));
 				return -1;
@@ -420,13 +411,14 @@ write_commands (int fd, BinaryBuffer *pbuf_write)
 struct LogManagerState {
 	const char *dir;
 	int log_id;		// ID of the current log.
-	FILE *log_fp;	// Point to the current log.
+	FILE *log_fp;		// Point to the current log.
 	size_t log_size;	// Number of bytes in the current log.
 	size_t log_cut_size;	// Max number of bytes for each log.
 };
 
 static void
-manager_init_state (struct LogManagerState *pstate, const char *dir, size_t log_cut_size) {
+manager_init_state (struct LogManagerState *pstate, const char *dir, size_t log_cut_size)
+{
 	pstate->dir = dir;
 	pstate->log_id = -1;
 	pstate->log_fp = NULL;
@@ -435,7 +427,8 @@ manager_init_state (struct LogManagerState *pstate, const char *dir, size_t log_
 }
 
 static void
-manager_get_log_name (struct LogManagerState *pstate, char *out_buf, size_t out_buf_size) {
+manager_get_log_name (struct LogManagerState *pstate, char *out_buf, size_t out_buf_size)
+{
 	assert(out_buf_size > 0);
 	size_t dir_len = strlen(pstate->dir);
 	// Remove trailing slashes
@@ -451,7 +444,8 @@ manager_get_log_name (struct LogManagerState *pstate, char *out_buf, size_t out_
 }
 
 static int
-manager_start_new_log (struct LogManagerState *pstate, int fifo_fd) {
+manager_start_new_log (struct LogManagerState *pstate, int fifo_fd)
+{
 	static char filename[1024] = {};
 	int ret;
 	if (pstate->log_fp != NULL) {	// end the last log
@@ -462,19 +456,19 @@ manager_start_new_log (struct LogManagerState *pstate, int fifo_fd) {
 
 		// Wirte msg type to pipe
 		ret = write(fifo_fd, &fifo_msg_type, sizeof(short));
-		if(ret<0){
+		if (ret < 0) {
 			return -1;
 		}
 
 		// Write len of filename
 		ret = write(fifo_fd, &msg_len, sizeof(short));
-		if(ret<0){
+		if (ret < 0) {
 			return -1;
 		}
 
 		// Write filename of ended log to pipe
 		ret = write(fifo_fd, filename, msg_len);
-		if(ret<0){
+		if (ret < 0) {
 			return -1;
 		}
 
@@ -492,28 +486,27 @@ manager_start_new_log (struct LogManagerState *pstate, int fifo_fd) {
 		short msg_len = strlen(filename);
 		// Wirte msg type to pipe
 		ret = write(fifo_fd, &fifo_msg_type, sizeof(short));
-		if(ret<0){
+		if (ret < 0) {
 			return -1;
 		}
 
 		// Write len of filename
 		ret = write(fifo_fd, &msg_len, sizeof(short));
-		if(ret<0){
+		if (ret < 0) {
 			return -1;
 		}
 
 		// Write filename of ended log to pipe
 		ret = write(fifo_fd, filename, msg_len);
-		if(ret<0){
+		if (ret < 0) {
 			return -1;
 		}
-        // char tmp[4096];
-        // sprintf(tmp,"su -c chmod 644 %s\n",filename);
-        // system(tmp);
-        char tmp[4096];
-        sprintf(tmp,"chmod 777 %s\n",filename);
-        system(tmp);
-
+		// char tmp[4096];
+		// sprintf(tmp, "su -c chmod 644 %s\n", filename);
+		// system(tmp);
+		char tmp[4096];
+		sprintf(tmp, "chmod 777 %s\n", filename);
+		system(tmp);
 	} else {
 		return -1;
 	}
@@ -523,7 +516,8 @@ manager_start_new_log (struct LogManagerState *pstate, int fifo_fd) {
 // When appending new data to logs, call this function to maintain states.
 // If the size of the current log exceeds log_cut_size, a new log file is created.
 static int
-manager_append_log (struct LogManagerState *pstate, int fifo_fd, size_t msg_len) {
+manager_append_log (struct LogManagerState *pstate, int fifo_fd, size_t msg_len)
+{
 
 	if (pstate->log_size + msg_len > pstate->log_cut_size) {
 		int ret = manager_start_new_log(pstate, fifo_fd);
@@ -535,82 +529,80 @@ manager_append_log (struct LogManagerState *pstate, int fifo_fd, size_t msg_len)
 	return 0;
 }
 
-int __enable_logging_libdiag(int mode){
+static int
+__enable_logging_libdiag (int mode)
+{
+	int ret;
 
-    int ret;
+	const char LIB_DIAG_PATH[] = "/system/vendor/lib/libdiag.so";
+	void *handle;
+	char *error;
+	D_FUNC diag_switch_logging = NULL;
+	I_FUNC Diag_LSM_Init = NULL, Diag_LSM_DeInit = NULL;
+	int *max_file_size;
+	char *output_dir;
 
-    const char LIB_DIAG_PATH[] = "/system/vendor/lib/libdiag.so";
-    void *handle;
-    char *error;
-    D_FUNC diag_switch_logging = NULL;
-    I_FUNC Diag_LSM_Init = NULL, Diag_LSM_DeInit = NULL;
-    int *max_file_size;
-    char *output_dir;
+	handle = dlopen(LIB_DIAG_PATH, RTLD_NOW);
+	if (!handle) {
+		// fLOGD(stderr, "%s\n", dlerror());
+	} else {
+		// LOGD("%s: test 1\n", __func__);
+		*(void **) (&diag_switch_logging) = dlsym(handle, "diag_switch_logging");
+		*(void **) (&Diag_LSM_Init) = dlsym(handle, "Diag_LSM_Init");
+		*(void **) (&Diag_LSM_DeInit) = dlsym(handle, "Diag_LSM_DeInit");
+		max_file_size = (int*) dlsym(handle, "max_file_size");
+		output_dir = (char*) dlsym(handle, "output_dir");
+		char *dir_p = (char *) &output_dir;
 
-    handle = dlopen(LIB_DIAG_PATH, RTLD_NOW);
-    if (!handle) {
-        // fLOGD(stderr, "%s\n", dlerror());
-    }
-    else{
-        // LOGD("%s: test 1\n", __func__);
-        *(void **) (&diag_switch_logging) = dlsym(handle, "diag_switch_logging");
-        *(void **) (&Diag_LSM_Init) = dlsym(handle, "Diag_LSM_Init");
-        *(void **) (&Diag_LSM_DeInit) = dlsym(handle, "Diag_LSM_DeInit");
-        max_file_size = (int*) dlsym(handle, "max_file_size");
-        output_dir = (char*) dlsym(handle, "output_dir");
-        char *dir_p = (char *) &output_dir;
+		if (max_file_size)
+			*max_file_size = 1; // Minimal size, beneficial for real-time features
 
-        if(max_file_size)
-            *max_file_size = 1; //Minimal size, beneficial for real-time features
+		// LOGD("%s: test 2\n", __func__);
+		// if (Diag_LSM_DeInit)
+		// 	Diag_LSM_DeInit();
+		// LOGD("%s: test 3\n", __func__);
+		if (Diag_LSM_Init)
+			ret = Diag_LSM_Init();
+		// LOGD("%s: test 4\n", __func__);
+		char default_output_dir[100] = "/sdcard/diag_logs/";
 
-        // LOGD("%s: test 2\n", __func__);
-        // if(Diag_LSM_DeInit)
-        //     Diag_LSM_DeInit();
-        // LOGD("%s: test 3\n", __func__);
-        if(Diag_LSM_Init)
-            ret = Diag_LSM_Init();
-        // LOGD("%s: test 4\n", __func__);
-        char default_output_dir[100] = "/sdcard/diag_logs/";
+		if (dir_p)
+			strlcpy(dir_p, default_output_dir, sizeof(default_output_dir));
 
-        if(dir_p)
-            strlcpy(dir_p,default_output_dir,sizeof(default_output_dir));
+		// LOGD("%s: test 5\n", __func__);
 
-        // LOGD("%s: test 5\n", __func__);
+		if (output_dir)
+			mkdir((const char *) &output_dir, 504LL);
 
-        if(output_dir)
-            mkdir((const char *) &output_dir, 504LL);
+		// LOGD("%s: test 6\n", __func__);
 
-        // LOGD("%s: test 6\n", __func__);
+		if (diag_switch_logging) {
+			ret = (int) (*diag_switch_logging)(mode, (int) &output_dir);
+		}
 
-        if(diag_switch_logging){
+		// dlclose(handle);
+	}
 
-
-            ret = (int)(*diag_switch_logging)(mode,(int) &output_dir);
-        }
-
-        // dlclose(handle);
-    }
-
-    return ret;
+	return ret;
 }
 
-int enable_logging(int fd, int mode){
+static int
+enable_logging (int fd, int mode)
+{
+	int ret = -1;
 
-    int ret = -1;
-
-    /*
-     * EXPERIMENTAL (NEXUS 6 ONLY): 
-     * 1. check remote_dev
-     * 2. Register a DCI client
-     * 3. Send DCI control command
-     */
-    ret = ioctl(fd, DIAG_IOCTL_REMOTE_DEV, (char *) &remote_dev); 
-    if (ret < 0){
-	        printf("ioctl DIAG_IOCTL_REMOTE_DEV fails, with ret val = %d\n", ret);
-	    	perror("ioctl DIAG_IOCTL_REMOTE_DEV");
-	} 
-	else{
-		LOGD("DIAG_IOCTL_REMOTE_DEV remote_dev=%d\n",remote_dev);
+	/*
+	 * EXPERIMENTAL (NEXUS 6 ONLY):
+	 * 1. check remote_dev
+	 * 2. Register a DCI client
+	 * 3. Send DCI control command
+	 */
+	ret = ioctl(fd, DIAG_IOCTL_REMOTE_DEV, (char *) &remote_dev);
+	if (ret < 0) {
+		printf("ioctl DIAG_IOCTL_REMOTE_DEV fails, with ret val = %d\n", ret);
+		perror("ioctl DIAG_IOCTL_REMOTE_DEV");
+	} else {
+		LOGD("DIAG_IOCTL_REMOTE_DEV remote_dev=%d\n", remote_dev);
 	}
 
 	// Register a DCI client
@@ -620,35 +612,33 @@ int enable_logging(int fd, int mode){
 	dci_client.signal_type = SIGPIPE;
 	// dci_client.token = remote_dev;
 	dci_client.token = 0;
-	ret = ioctl(fd, DIAG_IOCTL_DCI_REG, (char *) &dci_client); 
-    if (ret < 0){
-	        printf("ioctl DIAG_IOCTL_DCI_REG fails, with ret val = %d\n", ret);
-	    	perror("ioctl DIAG_IOCTL_DCI_REG");
-	} 
-	else{
+	ret = ioctl(fd, DIAG_IOCTL_DCI_REG, (char *) &dci_client);
+	if (ret < 0) {
+		printf("ioctl DIAG_IOCTL_DCI_REG fails, with ret val = %d\n", ret);
+		perror("ioctl DIAG_IOCTL_DCI_REG");
+	} else {
 		client_id = ret;
 		printf("DIAG_IOCTL_DCI_REG client_id=%d\n", client_id);
 	}
 
 	// Nexus-6-only logging optimizations
 	unsigned int b_optimize = 1;
-	ret = ioctl(fd, DIAG_IOCTL_OPTIMIZED_LOGGING, (char *) &b_optimize); 
-	if (ret < 0){
-	        printf("ioctl DIAG_IOCTL_OPTIMIZED_LOGGING fails, with ret val = %d\n", ret);
-	    	perror("ioctl DIAG_IOCTL_OPTIMIZED_LOGGING");
-	} 
-	// ret = ioctl(fd, DIAG_IOCTL_OPTIMIZED_LOGGING_FLUSH, NULL); 
-	// if (ret < 0){
-	//         printf("ioctl DIAG_IOCTL_OPTIMIZED_LOGGING_FLUSH fails, with ret val = %d\n", ret);
-	//     	perror("ioctl DIAG_IOCTL_OPTIMIZED_LOGGING_FLUSH");
-	// } 
-
+	ret = ioctl(fd, DIAG_IOCTL_OPTIMIZED_LOGGING, (char *) &b_optimize);
+	if (ret < 0) {
+		printf("ioctl DIAG_IOCTL_OPTIMIZED_LOGGING fails, with ret val = %d\n", ret);
+		perror("ioctl DIAG_IOCTL_OPTIMIZED_LOGGING");
+	}
+	// ret = ioctl(fd, DIAG_IOCTL_OPTIMIZED_LOGGING_FLUSH, NULL);
+	// if (ret < 0) {
+	// 	printf("ioctl DIAG_IOCTL_OPTIMIZED_LOGGING_FLUSH fails, with ret val = %d\n", ret);
+	// 	perror("ioctl DIAG_IOCTL_OPTIMIZED_LOGGING_FLUSH");
+	// }
 
 	/*
-     * TODO: cleanup the diag before start
-     * 1. Drain the buffer: prevent outdate logs next time
-     * 2. Clean up masks: prevent enable_log bug next time
-     */
+	 * TODO: cleanup the diag before start
+	 * 1. Drain the buffer: prevent outdate logs next time
+	 * 2. Clean up masks: prevent enable_log bug next time
+	 */
 
 	/*
 	 * DIAG_IOCTL_LSM_DEINIT, try if it can clear buffer
@@ -656,148 +646,169 @@ int enable_logging(int fd, int mode){
 
 	/*
 	ret = ioctl(fd, DIAG_IOCTL_LSM_DEINIT, NULL);
-	if (ret < 0){
-        printf("ioctl DIAG_IOCTL_LSM_DEINIT fails, with ret val = %d\n", ret);
-    	perror("ioctl DIAG_IOCTL_LSM_DEINIT");
-    }
-    */
+	if (ret < 0) {
+		printf("ioctl DIAG_IOCTL_LSM_DEINIT fails, with ret val = %d\n", ret);
+		perror("ioctl DIAG_IOCTL_LSM_DEINIT");
+	}
+	*/
 
-    // ret = ioctl(fd, DIAG_IOCTL_DCI_CLEAR_LOGS, (char *) &client_id);  
-    // if (ret < 0){
-    //     printf("ioctl DIAG_IOCTL_DCI_CLEAR_LOGS fails, with ret val = %d\n", ret);
-    // 	perror("ioctl DIAG_IOCTL_DCI_CLEAR_LOGS");
-    // }
-    // ret = ioctl(fd, DIAG_IOCTL_DCI_CLEAR_EVENTS, (char *) &client_id);  
-    // if (ret < 0){
-    //     printf("ioctl DIAG_IOCTL_DCI_CLEAR_EVENTS fails, with ret val = %d\n", ret);
-    // 	perror("ioctl DIAG_IOCTL_DCI_CLEAR_EVENTS");
-    // }
+	// ret = ioctl(fd, DIAG_IOCTL_DCI_CLEAR_LOGS, (char *) &client_id);
+	// if (ret < 0) {
+	// 	printf("ioctl DIAG_IOCTL_DCI_CLEAR_LOGS fails, with ret val = %d\n", ret);
+	// 	perror("ioctl DIAG_IOCTL_DCI_CLEAR_LOGS");
+	// }
+	// ret = ioctl(fd, DIAG_IOCTL_DCI_CLEAR_EVENTS, (char *) &client_id);
+	// if (ret < 0) {
+	// 	printf("ioctl DIAG_IOCTL_DCI_CLEAR_EVENTS fails, with ret val = %d\n", ret);
+	// 	perror("ioctl DIAG_IOCTL_DCI_CLEAR_EVENTS");
+	// }
 
-    /*
-     * EXPERIMENTAL (NEXUS 6 ONLY): configure the buffering mode to circular
-     */
-    struct diag_buffering_mode_t buffering_mode;
-    // buffering_mode.peripheral = remote_dev;
-    buffering_mode.peripheral = 0;
-    buffering_mode.mode = DIAG_BUFFERING_MODE_STREAMING;
-    buffering_mode.high_wm_val = DEFAULT_HIGH_WM_VAL;
-    buffering_mode.low_wm_val = DEFAULT_LOW_WM_VAL;
+	/*
+	 * EXPERIMENTAL (NEXUS 6 ONLY): configure the buffering mode to circular
+	 */
+	struct diag_buffering_mode_t buffering_mode;
+	// buffering_mode.peripheral = remote_dev;
+	buffering_mode.peripheral = 0;
+	buffering_mode.mode = DIAG_BUFFERING_MODE_STREAMING;
+	buffering_mode.high_wm_val = DEFAULT_HIGH_WM_VAL;
+	buffering_mode.low_wm_val = DEFAULT_LOW_WM_VAL;
 
-    ret = ioctl(fd, DIAG_IOCTL_PERIPHERAL_BUF_CONFIG, (char *) &buffering_mode);  
-    if (ret < 0){
-        printf("ioctl DIAG_IOCTL_PERIPHERAL_BUF_CONFIG fails, with ret val = %d\n", ret);
-    	perror("ioctl DIAG_IOCTL_PERIPHERAL_BUF_CONFIG");
-    }
+	ret = ioctl(fd, DIAG_IOCTL_PERIPHERAL_BUF_CONFIG, (char *) &buffering_mode);
+	if (ret < 0) {
+		printf("ioctl DIAG_IOCTL_PERIPHERAL_BUF_CONFIG fails, with ret val = %d\n", ret);
+		perror("ioctl DIAG_IOCTL_PERIPHERAL_BUF_CONFIG");
+	}
 
+	// uint8_t peripheral = 0;
+	// for (; peripheral <= LAST_PERIPHERAL; peripheral++) {
+	// 	ret = ioctl(fd, DIAG_IOCTL_PERIPHERAL_BUF_DRAIN, (char *) &peripheral);
+	// 	if (ret < 0) {
+	// 		printf("ioctl DIAG_IOCTL_PERIPHERAL_BUF_DRAIN fails, with ret val = %d\n", ret);
+	// 		perror("ioctl DIAG_IOCTL_PERIPHERAL_BUF_DRAIN");
+	// 	}
 
-    /*
-     * Enable logging mode
-     * Reference: https://android.googlesource.com/kernel/msm.git/+/android-6.0.0_r0.9/drivers/char/diag/diagchar_core.c
-     */
-    ret = -1;
-    if (ret < 0) {
-        /* Android 9.0 mode
-         * * Reference: https://android.googlesource.com/kernel/msm.git/+/android-9.0.0_r0.31/drivers/char/diag/diagchar_core.c
-         * */
-        struct diag_logging_mode_param_t_pie new_mode;
-        new_mode.req_mode = mode;
-        new_mode.mode_param = 0;
-        new_mode.pd_mask = 0;
-        new_mode.peripheral_mask = DIAG_CON_ALL;
-        ret = ioctl(fd, DIAG_IOCTL_SWITCH_LOGGING, (char *)& new_mode);
-    }
-    if (ret < 0) {
-        // LOGD("Android-9.0 ioctl SWITCH_LOGGING fails: %s \n", strerror(errno));
-        /* Android 7.0 mode
-         * * Reference: https://android.googlesource.com/kernel/msm.git/+/android-7.1.0_r0.3/drivers/char/diag/diagchar_core.c
-         * */
-        struct diag_logging_mode_param_t new_mode;
-        new_mode.req_mode = mode;
-        new_mode.peripheral_mask = DIAG_CON_ALL;
-        new_mode.mode_param = 0;
-        // LOGD("&new_mode=%p peripheral_mask=%d req_mode=%d mode_param=%d\n", &new_mode, new_mode.peripheral_mask, new_mode.req_mode, new_mode.mode_param);
-        ret = ioctl(fd, DIAG_IOCTL_SWITCH_LOGGING, (char *)& new_mode);
-    }
-    if (ret < 0) {
-        // LOGD("Android-7.0 ioctl SWITCH_LOGGING fails: %s \n", strerror(errno));
-        // Reference: https://android.googlesource.com/kernel/msm.git/+/android-6.0.0_r0.9/drivers/char/diag/diagchar_core.c
-        ret = ioctl(fd, DIAG_IOCTL_SWITCH_LOGGING, (char *) &mode);
-    }
-    if (ret < 0) {
-        // LOGD("ioctl SWITCH_LOGGING fails: %s \n", strerror(errno));
-        // perror("ioctl SWITCH_LOGGING");
-        // Yuanjie: the following works for Samsung S5
-        ret = ioctl(fd, DIAG_IOCTL_SWITCH_LOGGING, (char *) mode);
-    }
-    if (ret < 0) {
-        // LOGD("Android-7.0 ioctl SWITCH_LOGGING fails: %s \n", strerror(errno));
-        // perror("Alternative ioctl SWITCH_LOGGING");
-        // Yuanjie: the following is used for Xiaomi RedMi 4
-        ret = ioctl(fd, DIAG_IOCTL_SWITCH_LOGGING, (char *) mode, 12, 0, 0, 0, 0);
-    }
-    if (ret < 0) {
-        // LOGD("S7 Edge ioctl SWITCH_LOGGING fails: %s \n", strerror(errno));
-        // perror("Alternative ioctl SWITCH_LOGGING");
-        // XiaoMI 6 7.1.1
-        ret = ioctl(fd, DIAG_IOCTL_SWITCH_LOGGING, mode);
-    }
-    if (ret < 0) {
-        // LOGD("XiaoMI method 1 ioctl SWITCH_LOGGING fails: %s \n", strerror(errno));
-        // perror("Alternative ioctl SWITCH_LOGGING");
-        ret = ioctl(fd, DIAG_IOCTL_SWITCH_LOGGING, &mode, 12, 0, 0, 0, 0);
-    }
-    if (ret < 0) {
-        // LOGD("XiaoMI method 2 ioctl SWITCH_LOGGING fails: %s \n", strerror(errno));
-        /* Ultimate approach: Use libdiag.so */
-        ret = __enable_logging_libdiag(mode);    //FIXME: 0921, uncomment it
-    }
-    if (ret >= 0) {
-        // LOGD("Enable logging mode success.\n");
+	// 	/*
+	// 	 * EXPERIMENTAL (NEXUS 6 ONLY): configure the buffering mode to circular
+	// 	*/
+	// 	struct diag_buffering_mode_t buffering_mode;
+	// 	buffering_mode.peripheral = peripheral;
+	// 	buffering_mode.mode = DIAG_BUFFERING_MODE_STREAMING;
+	// 	buffering_mode.high_wm_val = DEFAULT_HIGH_WM_VAL;
+	// 	buffering_mode.low_wm_val = DEFAULT_LOW_WM_VAL;
+	//
+	// 	ret = ioctl(fd, DIAG_IOCTL_PERIPHERAL_BUF_CONFIG, (char *) &buffering_mode);
+	// 	if (ret < 0) {
+	// 		printf("ioctl DIAG_IOCTL_PERIPHERAL_BUF_CONFIG fails, with ret val = %d\n", ret);
+	// 		perror("ioctl DIAG_IOCTL_PERIPHERAL_BUF_CONFIG");
+	// 	}
+	// }
 
-        // Register a DCI client
-        struct diag_dci_reg_tbl_t dci_client;
-        dci_client.client_id = 0;
-        dci_client.notification_list = 0;
-        dci_client.signal_type = SIGPIPE;
-        // dci_client.token = remote_dev;
-        dci_client.token = 0;
-        ret = ioctl(fd, DIAG_IOCTL_DCI_REG, (char *) &dci_client); 
-        if (ret < 0){
-                // LOGD("ioctl DIAG_IOCTL_DCI_REG fails, with ret val = %d\n", ret);
-                // perror("ioctl DIAG_IOCTL_DCI_REG");
-        } 
-        else{
-            client_id = ret;
-            // LOGD("DIAG_IOCTL_DCI_REG client_id=%d\n", client_id);
-        }
+	/*
+	 * Enable logging mode
+	 * Reference: https://android.googlesource.com/kernel/msm.git/+/android-6.0.0_r0.9/drivers/char/diag/diagchar_core.c
+	 */
+	ret = -1;
+	if (ret < 0) {
+		/* Android 9.0 mode
+		 * Reference: https://android.googlesource.com/kernel/msm.git/+/android-9.0.0_r0.31/drivers/char/diag/diagchar_core.c
+		 */
+		struct diag_logging_mode_param_t_pie new_mode;
+		new_mode.req_mode = mode;
+		new_mode.mode_param = 0;
+		new_mode.pd_mask = 0;
+		new_mode.peripheral_mask = DIAG_CON_ALL;
+		ret = ioctl(fd, DIAG_IOCTL_SWITCH_LOGGING, (char *) &new_mode);
+	}
+	if (ret < 0) {
+		// LOGD("Android-9.0 ioctl SWITCH_LOGGING fails: %s \n", strerror(errno));
+		/* Android 7.0 mode
+		 * Reference: https://android.googlesource.com/kernel/msm.git/+/android-7.1.0_r0.3/drivers/char/diag/diagchar_core.c
+		 */
+		struct diag_logging_mode_param_t new_mode;
+		new_mode.req_mode = mode;
+		new_mode.peripheral_mask = DIAG_CON_ALL;
+		new_mode.mode_param = 0;
+		// LOGD("&new_mode=%p peripheral_mask=%d req_mode=%d mode_param=%d\n", &new_mode, new_mode.peripheral_mask, new_mode.req_mode, new_mode.mode_param);
+		ret = ioctl(fd, DIAG_IOCTL_SWITCH_LOGGING, (char *) &new_mode);
+	}
+	if (ret < 0) {
+		// LOGD("Android-7.0 ioctl SWITCH_LOGGING fails: %s \n", strerror(errno));
+		// Reference: https://android.googlesource.com/kernel/msm.git/+/android-6.0.0_r0.9/drivers/char/diag/diagchar_core.c
+		ret = ioctl(fd, DIAG_IOCTL_SWITCH_LOGGING, (char *) &mode);
+	}
+	if (ret < 0) {
+		// LOGD("ioctl SWITCH_LOGGING fails: %s \n", strerror(errno));
+		// perror("ioctl SWITCH_LOGGING");
+		// Yuanjie: the following works for Samsung S5
+		ret = ioctl(fd, DIAG_IOCTL_SWITCH_LOGGING, (char *) mode);
+	}
+	if (ret < 0) {
+		// LOGD("Android-7.0 ioctl SWITCH_LOGGING fails: %s \n", strerror(errno));
+		// perror("Alternative ioctl SWITCH_LOGGING");
+		// Yuanjie: the following is used for Xiaomi RedMi 4
+		ret = ioctl(fd, DIAG_IOCTL_SWITCH_LOGGING, (char *) mode, 12, 0, 0, 0, 0);
+	}
+	if (ret < 0) {
+		// LOGD("S7 Edge ioctl SWITCH_LOGGING fails: %s \n", strerror(errno));
+		// perror("Alternative ioctl SWITCH_LOGGING");
+		// XiaoMI 6 7.1.1
+		ret = ioctl(fd, DIAG_IOCTL_SWITCH_LOGGING, mode);
+	}
+	if (ret < 0) {
+		// LOGD("XiaoMI method 1 ioctl SWITCH_LOGGING fails: %s \n", strerror(errno));
+		// perror("Alternative ioctl SWITCH_LOGGING");
+		ret = ioctl(fd, DIAG_IOCTL_SWITCH_LOGGING, &mode, 12, 0, 0, 0, 0);
+	}
+	if (ret < 0) {
+		// LOGD("XiaoMI method 2 ioctl SWITCH_LOGGING fails: %s \n", strerror(errno));
+		/* Ultimate approach: Use libdiag.so */
+		ret = __enable_logging_libdiag(mode);    // FIXME: 0921, uncomment it
+	}
+	if (ret >= 0) {
+		// LOGD("Enable logging mode success.\n");
 
-        /*
-         * Configure the buffering mode to circular
-         */
-        struct diag_buffering_mode_t buffering_mode;
-        // buffering_mode.peripheral = remote_dev;
-        buffering_mode.peripheral = 0;
-        buffering_mode.mode = DIAG_BUFFERING_MODE_STREAMING;
-        buffering_mode.high_wm_val = DEFAULT_HIGH_WM_VAL;
-        buffering_mode.low_wm_val = DEFAULT_LOW_WM_VAL;
+		// Register a DCI client
+		struct diag_dci_reg_tbl_t dci_client;
+		dci_client.client_id = 0;
+		dci_client.notification_list = 0;
+		dci_client.signal_type = SIGPIPE;
+		// dci_client.token = remote_dev;
+		dci_client.token = 0;
+		ret = ioctl(fd, DIAG_IOCTL_DCI_REG, (char *) &dci_client);
+		if (ret < 0) {
+			// LOGD("ioctl DIAG_IOCTL_DCI_REG fails, with ret val = %d\n", ret);
+			// perror("ioctl DIAG_IOCTL_DCI_REG");
+		} else {
+			client_id = ret;
+			// LOGD("DIAG_IOCTL_DCI_REG client_id=%d\n", client_id);
+		}
 
-        ret = ioctl(fd, DIAG_IOCTL_PERIPHERAL_BUF_CONFIG, (char *) &buffering_mode);  
-        if (ret < 0){
-            // LOGD("ioctl DIAG_IOCTL_PERIPHERAL_BUF_CONFIG fails, with ret val = %d\n", ret);
-            // perror("ioctl DIAG_IOCTL_PERIPHERAL_BUF_CONFIG");
-        }
+		/*
+		 * Configure the buffering mode to circular
+		 */
+		struct diag_buffering_mode_t buffering_mode;
+		// buffering_mode.peripheral = remote_dev;
+		buffering_mode.peripheral = 0;
+		buffering_mode.mode = DIAG_BUFFERING_MODE_STREAMING;
+		buffering_mode.high_wm_val = DEFAULT_HIGH_WM_VAL;
+		buffering_mode.low_wm_val = DEFAULT_LOW_WM_VAL;
 
-    } else {
-        // LOGD("Failed to enable logging mode: %s.\n", strerror(errno));
-    }
+		ret = ioctl(fd, DIAG_IOCTL_PERIPHERAL_BUF_CONFIG, (char *) &buffering_mode);
+		if (ret < 0) {
+			// LOGD("ioctl DIAG_IOCTL_PERIPHERAL_BUF_CONFIG fails, with ret val = %d\n", ret);
+			// perror("ioctl DIAG_IOCTL_PERIPHERAL_BUF_CONFIG");
+		}
 
-    return ret;
+	} else {
+		// LOGD("Failed to enable logging mode: %s.\n", strerror(errno));
+	}
+
+	return ret;
 }
 
 int
 main (int argc, char **argv)
 {
-
 	if (signal(SIGPIPE, sigpipe_handler) == SIG_ERR) {
 		LOGW("WARNING: diag_revealer cannot capture SIGPIPE\n");
 	}
@@ -807,7 +818,7 @@ main (int argc, char **argv)
 		printf("Author: Yuanjie Li, Jiayao Li\n");
 		printf("UCLA Wing Group\n");
 		printf("Usage: diag_revealer DIAG_CFG_PATH FIFO_PATH [LOG_OUTPUT_DIR] [LOG_CUT_SIZE (in MB)]\n");
-        return 0;
+		return 0;
 	}
 
 	// Read config file
@@ -821,86 +832,18 @@ main (int argc, char **argv)
 
 	// int fd = open("/dev/diag", O_RDWR);
 	// fd = open("/dev/diag", O_RDWR);
-	fd = open("/dev/diag", O_RDWR|O_LARGEFILE|O_NONBLOCK);
+	fd = open("/dev/diag", O_RDWR | O_LARGEFILE | O_NONBLOCK);
 	if (fd < 0) {
 		perror("open diag dev");
 		return -8002;
 	}
 
 	int ret;
-    // uint8_t peripheral = 0;
-    // for(;peripheral<=LAST_PERIPHERAL; peripheral++)
-    // {
-    // 	ret = ioctl(fd, DIAG_IOCTL_PERIPHERAL_BUF_DRAIN, (char *) &peripheral);
-	   //  if (ret < 0){
-	   //      printf("ioctl DIAG_IOCTL_PERIPHERAL_BUF_DRAIN fails, with ret val = %d\n", ret);
-	   //  	perror("ioctl DIAG_IOCTL_PERIPHERAL_BUF_DRAIN");
-	   //  }
 
-	   //  /*
-	   //   * EXPERIMENTAL (NEXUS 6 ONLY): configure the buffering mode to circular
-	   //   */
-	   //  struct diag_buffering_mode_t buffering_mode;
-	   //  buffering_mode.peripheral = peripheral;
-	   //  buffering_mode.mode = DIAG_BUFFERING_MODE_STREAMING;
-	   //  buffering_mode.high_wm_val = DEFAULT_HIGH_WM_VAL;
-	   //  buffering_mode.low_wm_val = DEFAULT_LOW_WM_VAL;
-
-	   //  ret = ioctl(fd, DIAG_IOCTL_PERIPHERAL_BUF_CONFIG, (char *) &buffering_mode);
-	   //  if (ret < 0){
-	   //      printf("ioctl DIAG_IOCTL_PERIPHERAL_BUF_CONFIG fails, with ret val = %d\n", ret);
-	   //  	perror("ioctl DIAG_IOCTL_PERIPHERAL_BUF_CONFIG");
-	   //  }
-    // }
-
-
-
-	// /*
-	//  * Enable logging mode
-	//  * Reference: https://android.googlesource.com/kernel/msm.git/+/android-6.0.0_r0.9/drivers/char/diag/diagchar_core.c
-	//  */
-	// ret = ioctl(fd, DIAG_IOCTL_SWITCH_LOGGING, (char *) &mode);
-	// if (ret < 0) {
-	// 	LOGD("ioctl SWITCH_LOGGING fails: %s \n", strerror(errno));
-	// 	perror("ioctl SWITCH_LOGGING");
-	// 	// Yuanjie: the following works for Samsung S5
-	// 	ret = ioctl(fd, DIAG_IOCTL_SWITCH_LOGGING, (char *) mode);
-	// 	if (ret < 0) {
-	// 		LOGD("Alternative ioctl SWITCH_LOGGING fails: %s \n", strerror(errno));
-	// 		perror("Alternative ioctl SWITCH_LOGGING");
-
-	// 		/* Android 7.0 mode
-	// 		 * Reference: https://android.googlesource.com/kernel/msm.git/+/android-7.1.0_r0.3/drivers/char/diag/diagchar_core.c
-	// 		 */
-
-	// 		struct diag_logging_mode_param_t new_mode;
-	// 		new_mode.req_mode = mode;
-	// 		new_mode.peripheral_mask = DIAG_CON_ALL;
-	// 		new_mode.mode_param = 0;
-
-	// 		ret = ioctl(fd, DIAG_IOCTL_SWITCH_LOGGING, (char *)& new_mode);
-	// 		if (ret < 0) {
-	// 			LOGD("Android-7.0 ioctl SWITCH_LOGGING fails: %s \n", strerror(errno));
-	// 			perror("Alternative ioctl SWITCH_LOGGING");
-
-
-	// 			ret = ioctl(fd, DIAG_IOCTL_SWITCH_LOGGING, &mode, 12, 0, 0, 0, 0);
-	// 			if (ret < 0) {
-	// 				LOGD("S7 Edge fails: %s \n", strerror(errno));
-	// 		    }
-	// 		}
-
-	// 	}
-
-	// }
-	// else{
-	// 	// printf("Older way of ioctl succeeds.\n");
-	// }
-
-    /*
-     * Enable logging mode
-     */
-    enable_logging(fd, mode);
+	/*
+	 * Enable logging mode
+	 */
+	enable_logging(fd, mode);
 
 	// Write commands to /dev/diag device to enable log collecting.
 	// LOGD("Before write_commands\n");
@@ -914,17 +857,17 @@ main (int argc, char **argv)
 	// Messages are output to this FIFO pipe
 	int pipesize = DIAG_FIFO_PIPE_SIZE;
 
-    // Set max frame pipe size: Prevent packet loss
+	// Set max frame pipe size: Prevent packet loss
 	char tmp[4096];
 	sprintf(tmp, "su -c \"echo -e %d > /proc/sys/fs/pipe-max-size\"", pipesize);
 	system(tmp);
 	// system("su -c \"ulimit -l unlimited\"");
 
-	struct rlimit rl; 
+	struct rlimit rl;
 	rl.rlim_max = pipesize;
 	rl.rlim_cur = pipesize;
-	setrlimit (RLIMIT_MEMLOCK, &rl); 
-	getrlimit (RLIMIT_CPU, &rl); 
+	setrlimit (RLIMIT_MEMLOCK, &rl);
+	getrlimit (RLIMIT_CPU, &rl);
 
 	// int fifo_fd = open(argv[2], O_WRONLY | O_NONBLOCK);	// block until the other end also calls open()
 	int fifo_fd = open(argv[2], O_WRONLY);	// block until the other end also calls open()
@@ -939,7 +882,7 @@ main (int argc, char **argv)
 	if (res < 0)
 		LOGI("Failed to set FIFO: %s\n", strerror(errno));
 
-	res = fcntl(fifo_fd, F_GETPIPE_SZ,pipesize);
+	res = fcntl(fifo_fd, F_GETPIPE_SZ, pipesize);
 	LOGI("FIFO capacity: %d\n", res);
 
 	struct LogManagerState state;
@@ -976,7 +919,7 @@ main (int argc, char **argv)
 		if (read_len > 0) {
 			if (*((int *)buf_read) == USER_SPACE_DATA_TYPE) {
 				int num_data = *((int *)(buf_read + 4));
-				// LOGI("num_data=%d\n",num_data);
+				// LOGI("num_data=%d\n", num_data);
 				int i = 0;
 				// long long offset = 8;
 				long long offset = remote_dev ? 12 : 8;
@@ -986,11 +929,11 @@ main (int argc, char **argv)
 					short fifo_msg_len;
 					double ts = get_posix_timestamp();
 
-					//Copy msg_len
+					// Copy msg_len
 					int msg_len = 0;
 					memcpy(&msg_len, buf_read + offset, sizeof(int));
 					// memcpy(&msg_len, buf_read + offset + 4, sizeof(int));
-					// LOGI("memcpy: msg_len=%d\n",msg_len);
+					// LOGI("memcpy: msg_len=%d\n", msg_len);
 					if (msg_len < 0)
 						continue;
 					// print_hex(buf_read + offset + 4, msg_len);
@@ -1002,7 +945,7 @@ main (int argc, char **argv)
 					// Write size of (payload + timestamp)
 					fifo_msg_len = (short) msg_len + 8;
 					ret_err = write(fifo_fd, &fifo_msg_len, sizeof(short));
-					if(ret_err<0){
+					if (ret_err < 0) {
 						// LOGI("Pipe closed, diag_revealer will exit");
 						LOGI("Pipe error (msg_len): %s", strerror(errno));
 						close(fd);
@@ -1011,7 +954,7 @@ main (int argc, char **argv)
 
 					// Write timestamp of sending payload to pipe
 					ret_err = write(fifo_fd, &ts, sizeof(double));
-					if(ret_err<0){
+					if (ret_err < 0) {
 						// LOGI("Pipe closed, diag_revealer will exit");
 						LOGI("Pipe error (timestamp): %s", strerror(errno));
 						close(fd);
@@ -1020,7 +963,7 @@ main (int argc, char **argv)
 
 					// Write payload to pipe
 					ret_err = write(fifo_fd, buf_read + offset + 4, msg_len);
-					if(ret_err<0){
+					if (ret_err < 0) {
 						LOGI("Pipe error (payload): %s", strerror(errno));
 						LOGD("Debug: msg_len=%d buf_read+offset+4=%s\n", msg_len, buf_read + offset + 4);
 						// LOGI("Pipe closed, diag_revealer will exit");
@@ -1033,7 +976,7 @@ main (int argc, char **argv)
 						int ret2 = manager_append_log(&state, fifo_fd, msg_len);
 						if (ret2 == 0) {
 							size_t log_res = fwrite(buf_read + offset + 4, sizeof(char), msg_len, state.log_fp);
-							if(log_res!=msg_len){
+							if (log_res != msg_len) {
 								LOGI("Fail to save logs. diag_revealer will exit");
 								close(fd);
 								return -1;
@@ -1048,9 +991,7 @@ main (int argc, char **argv)
 					}
 					offset += msg_len + 4;
 				}
-			}
-			else
-			{
+			} else {
 				// TODO: Check other raw binary types
 				// LOGI("Not USER_SPACE_DATA_TYPE: %d\n", *((int *)buf_read));
 			}
@@ -1059,26 +1000,21 @@ main (int argc, char **argv)
 		}
 	}
 
-	close(fd);
+	/*
+	 * Deregister the DCI client
+	 */
 
 	/*
-     * Deregister the DCI client
-     */
-
-    /*
-    ret = ioctl(fd, DIAG_IOCTL_DCI_DEINIT, (char *) &client_id);
-    if (ret < 0) {
+	ret = ioctl(fd, DIAG_IOCTL_DCI_DEINIT, (char *) &client_id);
+	if (ret < 0) {
 		LOGD("ioctl DIAG_IOCTL_DCI_DEINIT fails, with ret val = %d\n", ret);
 		perror("ioctl DIAG_IOCTL_DCI_DEINIT");
-	}
-	else
-	{
+	} else {
 		printf("ioctl DIAG_IOCTL_DCI_DEINIT: ret=%d\n", ret);
 	}
 	*/
 
-	return (ret < 0? ret: 0);
+	close(fd);
+
+	return (ret < 0 ? ret : 0);
 }
-
-
-


### PR DESCRIPTION
Hello, several days ago I'm trying to use MobileInsight on Android 10. Unfortunately, I suffered from some confusing random bugs. So I checked the code and tried to find how to fix them.

It's easy to see that those bugs are mainly related to diag_revealer.  And this pull request should fix them. I'll explain below what I have done in every commit in detail. (Actually, I have wrote detailed comments in the source code. But I will also explain them here.)

**Commit 51a21212bc59d407751b6df6977d7a2bbe4a00e6** (diag_revealer: Format the code.)

The commit only uniformed the code style, such as the indentation character (tabs or spaces) and so on. It also removed a few obviously useless commented code, and moved some comments to a correct place. In a word, this commit does not modify any code essentially (excluding comments, code styles, e.t.c.).

**Commit 0d7af7f96e61fe45c11ce1b7fc556978de5ba234** (diag_revealer: Explicitly probe DIAG_IOCTL_SWITCH_LOGGING's argument length.)

It optimized the way to enable logging mode (that is done by a DIAG_IOCTL_SWITCH_LOGGING ioctl system call).

Look at the comments:
```c
	/*
	 * Enable logging mode:
	 *
	 * DIAG_IOCTL_SWITCH_LOGGING has multiple versions. They require different arguments (which have
	 * different fields and whose lengths are also different). However, it seems there is no way to
	 * directly determine the version of DIAG_IOCTL_SWITCH_LOGGING. So some tricks can not be avoided
	 * here.
	 *
	 * A traditional way is to try one by one. But it can cause undefined behaviour. Specially, when
	 * a new verison of DIAG_IOCTL_SWITCH_LOGGING is introduced, it may not report an error. But some
	 * new fields will be out of bounds. Consequently, it may cause random bugs, which is confusing.
	 *
	 * So a more elegant way is to explicitly probe the length of DIAG_IOCTL_SWITCH_LOGGING's argument.
	 * And the version can be deduced from the length. It is not very precise, but it is enough at least
	 * for now.
	 */
```

**Commit 988c40bcb19053d0c3ecd2f1571c2756bf2afc89** (diag_revealer: Fix the method of using libdiag.so to switch logging.)

Although diag_revealer has provided a method of using libdiag.so to switch logging, it can work in no devices that I have tested on. The reason is that a variable (diag_fd or fd in libdiag.so) is not properly set and functions in libdiag.so will do nothing and fail directly. I fixed this.

Meanwhile, libdiag.so will create useless threads and they can prevent us from calling dlclose. A fake pthread_create is added to solve the problem. It works fine at least in all devices that I have tested on (listed below in comments).

```c
/*
 * Calling functions into libdiag.so will create several threads. For example,
 * in diag_switch_logging, three threads (disk_write_hdl, qsr4_db_parser_thread_hdl,
 * db_write_thread_hdl) will be created. But actually we don't need them at all.
 * Meanwhile we cannot call dlclose when these useless threads are still alive.
 * So the following fake pthread_create is used to prevent them from being created.
 *
 * Note this fake pthread_create may cause some unexpected side effects on another
 * untested version of libdiag.so. If so, futher modification is needed.
 *
 * Tested devices:
 *   Xiaomi Mi 5S            Android 7.1.2
 *   Huawei Nexus 6P         Android 8.0.0
 *   Xiaomi Redmi Note 8     Android 10.0.0
 *   Samsung Galaxy A90 5G   Android 10.0.0
 */
```

**Commit 8be5e516501d776683280af25360d35c965e5eb8** (diag_revealer: Android 10 support, and other several fixes.)

It introduced the support of Android 10 DIAG_IOCTL_SWITCH_LOGGING ioctl. The code will simply behave the same as libdiag.so.
Other several fixes include fixing Motorola Nexus 6 DIAG_IOCTL_OPTIMIZED_LOGGING ioctl, dealing with problems about linking private library libdiag.so in non-root environment, e.t.c.


Thanks for your review. And looking forward to any feedback (tests, suggestions and so on).